### PR TITLE
Added operation sendNextGoal

### DIFF
--- a/exploration.orogen
+++ b/exploration.orogen
@@ -59,7 +59,10 @@ task_context "Task" do
 
     operation("calculateGoals").
         doc("Triggers the calculation of a new list of goals")
-        
+
+    operation("sendNextGoal").returns('/bool').
+        doc("Send next from the list of goals")
+
     port_driven 'envire_environment_in', 'pose_samples'
 
     # If no new exploration points can be found

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -398,7 +398,7 @@ void Task::generateGoals()
     // If nothing new can be explored (numberOfExploredCells == 0) the exploration is over.
     double robot_length = _robot_length_x_m.get();
     double robot_width = _robot_width_y_m.get();
-    std::vector<base::samples::RigidBodyState> finGoals = planner.getCheapest(goals, 
+    finGoals = planner.getCheapest(goals, 
             robotStateCopy, true, robot_length, robot_width);
     LOG_INFO("Got %d final goals", finGoals.size());
     triggered = false;
@@ -414,7 +414,17 @@ void Task::generateGoals()
 
     _goals_out.write(finGoals);
     _all_goals_debug.write(all_goals);
-    if(finGoals.size() > 0) {
-        _goal_out_best.write(finGoals[0]);
+    nextGoal = finGoals.begin();
+    sendNextGoal();
+}
+
+bool Task::sendNextGoal()
+{
+    if(nextGoal < finGoals.end())
+    {
+        _goal_out_best.write(*nextGoal);
+        nextGoal++;
+        return true;
     }
+    return false;
 }

--- a/tasks/Task.hpp
+++ b/tasks/Task.hpp
@@ -28,7 +28,9 @@ namespace exploration {
     class Task : public TaskBase
     {
         friend class TaskBase;
-        protected:
+    protected:
+
+        virtual bool sendNextGoal();
 
         Planner planner;
         envire::Environment* mEnv; 
@@ -44,6 +46,9 @@ namespace exploration {
         
         base::samples::RigidBodyState start_vec;
         std::vector<base::Vector3d> goals;
+        std::vector<base::samples::RigidBodyState> finGoals;
+        std::vector<base::samples::RigidBodyState>::iterator nextGoal;
+		
         bool extractTraversability();
         bool extractMLS();
         //reveales areas that have been seen now


### PR DESCRIPTION
This allows to request the next exploration goal, for example after planning a path to the first one failed.